### PR TITLE
Prepare for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,30 @@ jobs:
     - name: Create archive
       run: ci/create-archive
 
-    - name: Upload
-      if: github.ref == 'refs/heads/master'
-      run: ci/upload-build git-bonsai artifacts/*.bz2
-      env:
-        UPLOAD_USERNAME: ${{ secrets.UPLOAD_USERNAME }}
-        UPLOAD_PRIVATE_KEY: ${{ secrets.UPLOAD_PRIVATE_KEY }}
-        UPLOAD_HOSTNAME: ${{ secrets.UPLOAD_HOSTNAME }}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: |
+          artifacts/*.bz2
+
+  server-upload:
+    needs: build
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Upload to builds.agateau.com
+        run: ci/upload-build clyde artifacts/*.bz2
+        env:
+          UPLOAD_USERNAME: ${{ secrets.UPLOAD_USERNAME }}
+          UPLOAD_PRIVATE_KEY: ${{ secrets.UPLOAD_PRIVATE_KEY }}
+          UPLOAD_HOSTNAME: ${{ secrets.UPLOAD_HOSTNAME }}

--- a/RELEASE_CHECK_LIST.md
+++ b/RELEASE_CHECK_LIST.md
@@ -1,48 +1,31 @@
-- [ ] Check working tree is up to date and clean:
+## Prepare
 
-    git checkout dev
-    git pull
-    git merge origin/master
+- [ ] Setup
 
-- [ ] Bump version number in Cargo.toml
+    pip install invoke
+    export VERSION=<the-new-version>
 
-- [ ] Update CHANGELOG.md:
+- [ ] Prepare
 
-    r!git log --pretty=format:'- \%s (\%an)' x.y.z-1..HEAD
+    invoke prepare-release
 
-- [ ] Commit and push
+## Tag
 
-    git commit
-    git push
+- [ ] Wait for CI to be happy
 
-- [ ] Prepare Cargo package
+- [ ] Create tag
 
-    cargo publish --dry-run
-    cargo package --list
+    invoke tag
 
-- [ ] Merge
+## Publish
 
-    git bonsai
-    git checkout master
-    git merge --no-ff dev
+    invoke download-artifacts
+    invoke publish
 
-- [ ] Tag
+## Post publish
 
-    git tag -a x.y.z
+- [ ] Bump version to x.y.z+1-alpha.1
 
-- [ ] Push
-
-    git push
-    git push --tags
-
-- [ ] Download build artifacts from CI
-
-- [ ] Publish Cargo package
-
-    cargo publish
-
-- [ ] Publish binaries on GitHub
-
-- [ ] Bump version to x.y.z+1-alpha
+    VERSION=<the-new-version> invoke update-version
 
 - [ ] Write blog post

--- a/ci/create-archive
+++ b/ci/create-archive
@@ -49,11 +49,19 @@ init_system
 init_checksum_cmd
 echo "Checksum command: $CHECKSUM_CMD"
 
-# Let caller define VERSION through an environment variable
-if [ -z "${VERSION:-}" ] ; then
-    VERSION=$(cargo pkgid | sed 's/.*#//')
-    VERSION=$VERSION+$(git show --no-patch --format=%cd-%h --date=format:%Y%d%mT%H%M%S)
-fi
+define_version() {
+    local cargo_version=$(cargo pkgid | sed 's/.*#//')
+    local git_version=$(git describe)
+    if [ "$git_version" = "$cargo_version" ] ; then
+        # Looks like we are on a tag, just use $cargo_version
+        VERSION=$cargo_version
+    else
+        # Not a tag, append date and commit hash
+        VERSION=$cargo_version+$(git show --no-patch --format=%cd-%h --date=format:%Y%m%dT%H%M%S)
+    fi
+}
+
+define_version
 
 ARTIFACTS_DIR=$PWD/artifacts
 ARCHIVE_DIR=$APP_NAME-$VERSION

--- a/ci/create-archive
+++ b/ci/create-archive
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 init_system() {
+    ARCH=$(uname -m)
+
     local out
     out=$(uname)
 
@@ -55,7 +57,7 @@ fi
 
 ARTIFACTS_DIR=$PWD/artifacts
 ARCHIVE_DIR=$APP_NAME-$VERSION
-ARCHIVE_NAME=$APP_NAME-$VERSION-$OS_NAME.tar.bz2
+ARCHIVE_NAME=$APP_NAME-$VERSION-$ARCH-$OS_NAME.tar.bz2
 
 rm -rf $ARTIFACTS_DIR
 mkdir -p $ARTIFACTS_DIR/$ARCHIVE_DIR

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,139 @@
+"""
+SPDX-FileCopyrightText: 2022 Aurélien Gâteau <mail@agateau.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+A set of tasks to simplify the release process. See RELEASE_CHECK_LIST.md
+for details.
+"""
+
+import os
+import re
+import shutil
+import sys
+
+from pathlib import Path
+from typing import List
+
+from invoke import task, run
+
+
+VERSION = os.environ["VERSION"]
+
+ARTIFACTS_DIR = Path("artifacts")
+
+MAIN_BRANCH = "master"
+
+
+def erun(*args, **kwargs):
+    """Like run, but with echo on"""
+    kwargs["echo"] = True
+    run(*args, **kwargs)
+
+
+def cerun(c, *args, **kwargs):
+    """Like Context.run, but with echo on"""
+    kwargs["echo"] = True
+    c.run(*args, **kwargs)
+
+
+def ask(msg: str) -> str:
+    """Show a message, wait for input and returns it"""
+    print(msg, end=" ")
+    return input()
+
+
+def is_ok(msg: str) -> bool:
+    """Show a message, append (y/n) and return True if user select y or Y"""
+    answer = ask(f"{msg} (y/n)").lower()
+    return answer == "y"
+
+
+@task
+def update_version(c):
+    path = Path("Cargo.toml")
+    text = path.read_text()
+    text, count = re.subn(r"^version = .*", f"version = \"{VERSION}\"", text,
+                          flags=re.MULTILINE)
+    assert count == 0 or count == 1
+    path.write_text(text)
+
+
+@task
+def prepare_release(c):
+    run(f"gh issue list -m {VERSION}", pty=True)
+    run("gh pr list", pty=True)
+    if not is_ok("Continue?"):
+        sys.exit(1)
+
+    erun(f"git checkout {MAIN_BRANCH}")
+    erun("git pull")
+    erun("git status -s")
+    if not is_ok("Continue?"):
+        sys.exit(1)
+
+    prepare_release2(c)
+
+
+@task
+def prepare_release2(c):
+    erun("git checkout -b prep-release")
+
+    update_version(c)
+
+    erun(f"changie batch {VERSION}")
+    print(f"Review/edit changelog (.changes/{VERSION}.md)")
+    if not is_ok("Looks good?"):
+        sys.exit(1)
+    erun("changie merge")
+    print("Review CHANGELOG.md")
+
+    if not is_ok("Looks good?"):
+        sys.exit(1)
+
+    prepare_release3(c)
+
+
+@task
+def prepare_release3(c):
+    erun("git add Cargo.toml CHANGELOG.md .changes")
+    erun(f"git commit -m 'Prepare {VERSION}'")
+    erun("git push -u origin prep-release")
+
+    erun("cargo publish --dry-run")
+    erun("cargo package --list")
+
+
+@task
+def tag(c):
+    erun(f"git checkout {MAIN_BRANCH}")
+    erun("git merge --no-ff prep-release")
+    erun(f"git tag -a {VERSION} -m 'Releasing version {VERSION}'")
+
+    if not is_ok("Push tag?"):
+        sys.exit(1)
+
+    erun("git push")
+    erun("git push --tags")
+    erun("git push -d origin prep-release")
+    erun("git branch -d prep-release")
+
+
+def get_artifact_list() -> List[Path]:
+    assert ARTIFACTS_DIR.exists()
+    return list(ARTIFACTS_DIR.glob("*.tar.gz")) + list(ARTIFACTS_DIR.glob("*.zip"))
+
+
+@task
+def download_artifacts(c):
+    if ARTIFACTS_DIR.exists():
+        shutil.rmtree(ARTIFACTS_DIR)
+    ARTIFACTS_DIR.mkdir()
+    erun(f"gh run download --dir {ARTIFACTS_DIR}", pty=True)
+
+
+@task
+def publish(c):
+    files_str = " ".join(str(x) for x in get_artifact_list())
+    erun(f"gh release create {VERSION} -F.changes/{VERSION}.md {files_str}")
+    erun("cargo publish")


### PR DESCRIPTION
- Update dependencies
- Fix MultiSelect being hard to read
- Add architecture to archive name
- Use version code from Clyde
- Update release process
- Centralize upload to avoid Windows 2019 upload breakage
