### PR TITLE
Fix tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,16 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        # Use `fetch-depth: 0` otherwise `git describe` does not see valid
+        # tags, causing ci/create-archive to create snapshot archives. This
+        # also requires the "Fix actions/checkout bug" step below to work.
+        fetch-depth: 0
+
+    # See https://github.com/actions/checkout/issues/290#issuecomment-680260080
+    - name: Fix actions/checkout bug
+      run: git fetch --force --tags
 
     - name: Build
       run: ci/build-app
@@ -51,7 +60,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/ci/create-archive
+++ b/ci/create-archive
@@ -75,7 +75,6 @@ rm -rf $ARTIFACTS_DIR
 mkdir -p $ARTIFACTS_DIR/$ARCHIVE_DIR
 
 echo "Copying and stripping binary"
-ls
 cp target/release/$EXE_NAME $ARTIFACTS_DIR/$ARCHIVE_DIR
 strip $ARTIFACTS_DIR/$ARCHIVE_DIR/$EXE_NAME
 
@@ -84,7 +83,7 @@ cp $DATA_FILES $ARTIFACTS_DIR/$ARCHIVE_DIR
 
 echo "Creating archive $ARTIFACTS_DIR/$ARCHIVE_NAME"
 cd $ARTIFACTS_DIR
-tar -cjf $ARCHIVE_NAME $ARCHIVE_DIR
+tar -cjvf $ARCHIVE_NAME $ARCHIVE_DIR
 
 echo "Computing checksum"
 $CHECKSUM_CMD $ARCHIVE_NAME

--- a/ci/create-archive
+++ b/ci/create-archive
@@ -50,15 +50,19 @@ init_checksum_cmd
 echo "Checksum command: $CHECKSUM_CMD"
 
 define_version() {
-    local cargo_version=$(cargo pkgid | sed 's/.*#//')
-    local git_version=$(git describe)
-    if [ "$git_version" = "$cargo_version" ] ; then
-        # Looks like we are on a tag, just use $cargo_version
-        VERSION=$cargo_version
-    else
-        # Not a tag, append date and commit hash
-        VERSION=$cargo_version+$(git show --no-patch --format=%cd-%h --date=format:%Y%m%dT%H%M%S)
-    fi
+    local describe=$(git describe)
+    echo "git describe: $describe"
+    case "$describe" in
+        *-*-g*)
+            echo "Building a snapshot"
+            VERSION=${describe//-*/}+$(git show --no-patch --format=%cd-%h --date=format:%Y%m%dT%H%M%S)
+            ;;
+        *)
+            echo "Building from a tag"
+            VERSION=$describe
+            ;;
+    esac
+    echo "VERSION=$VERSION"
 }
 
 define_version


### PR DESCRIPTION
- Fix CI creating snapshot archives for tags
- When building from a tag, use the tag for the archive version
- Improve create-archive output
