### PR TITLE
Detect default branch and consider it protected

### DIFF
--- a/.changes/unreleased/Changed-20221111-191851.yaml
+++ b/.changes/unreleased/Changed-20221111-191851.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Git Bonsai now detects the default branch and always considers it protected.
+time: 2022-11-11T19:18:51.239479015+01:00

--- a/src/appui.rs
+++ b/src/appui.rs
@@ -40,4 +40,6 @@ pub trait AppUi {
     fn select_identical_branches_to_delete(&self, branches: &[String]) -> Vec<String>;
 
     fn select_identical_branches_to_delete_keep_one(&self, branches: &[String]) -> Vec<String>;
+
+    fn select_default_branch(&self, branches: &[String]) -> Option<String>;
 }

--- a/src/batchappui.rs
+++ b/src/batchappui.rs
@@ -51,4 +51,8 @@ impl AppUi for BatchAppUi {
         to_delete.remove(0);
         to_delete
     }
+
+    fn select_default_branch(&self, _branches: &[String]) -> Option<String> {
+        None
+    }
 }

--- a/src/interactiveappui.rs
+++ b/src/interactiveappui.rs
@@ -101,4 +101,12 @@ impl AppUi for InteractiveAppUi {
             .map(|&x| items[x].clone())
             .collect::<Vec<String>>()
     }
+
+    fn select_default_branch(&self, branches: &[String]) -> Option<String> {
+        let mut items = branches.to_vec();
+        items.sort();
+
+        tui::select_one("Select the branch to use as the default branch", &items)
+            .map(|x| items[x].clone())
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,7 +22,7 @@
  */
 use console::style;
 
-use dialoguer::MultiSelect;
+use dialoguer::{MultiSelect, Select};
 
 pub fn log_warning(msg: &str) {
     println!("{}", style(format!("Warning: {}", msg)).yellow());
@@ -43,5 +43,14 @@ pub fn select(msg: &str, items: &[String]) -> Vec<usize> {
         .with_prompt(msg)
         .items_checked(&checked_items[..])
         .interact()
+        .unwrap()
+}
+
+pub fn select_one(msg: &str, items: &[String]) -> Option<usize> {
+    Select::new()
+        .with_prompt(msg)
+        .items(items)
+        .default(0)
+        .interact_opt()
         .unwrap()
 }

--- a/tests/integ.rs
+++ b/tests/integ.rs
@@ -30,7 +30,7 @@ mod integ {
     use claim::*;
     use predicates::prelude::*;
 
-    use git_bonsai::app::{self, App, AppError};
+    use git_bonsai::app::{self, App, AppError, DEFAULT_BRANCH_CONFIG_KEY};
     use git_bonsai::batchappui::BatchAppUi;
     use git_bonsai::cliargs::CliArgs;
     use git_bonsai::git::create_test_repository;
@@ -39,6 +39,8 @@ mod integ {
     fn create_repository() -> (assert_fs::TempDir, Repository) {
         let dir = assert_fs::TempDir::new().unwrap();
         let repo = create_test_repository(dir.path());
+        repo.set_config_key(DEFAULT_BRANCH_CONFIG_KEY, "master")
+            .unwrap();
         (dir, repo)
     }
 
@@ -289,14 +291,14 @@ mod integ {
         .unwrap();
 
         // WHEN app is instantiated
-        let app = create_app(&dir.path().to_str().unwrap(), &[]);
+        let mut app = create_app(&dir.path().to_str().unwrap(), &[]);
+        app.add_default_branch_to_protected_branches().unwrap();
 
-        // THEN app.protected_branches contains the custom protected branch and the default
-        // branches
-        let expected_branches: HashSet<String> = ["master", "main", "custom1", "custom2"]
+        // THEN app.protected_branches contains all protected branches
+        let expected_branches: HashSet<String> = ["custom1", "custom2", "master"]
             .iter()
             .map(|x| x.to_string())
             .collect();
-        assert_eq!(app.protected_branches, expected_branches);
+        assert_eq!(app.get_protected_branches(), expected_branches);
     }
 }


### PR DESCRIPTION
- No more hard-coded "main" and "master" just in case.
- No more failure to fallback after deleting the current branch because it
  has been merged.
