### PR TITLE
remove prints

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -377,7 +377,17 @@ impl App {
         Ok(())
     }
 
-    pub fn run(&mut self) -> Result<(), AppError> {
+    pub fn run(&mut self) -> i32 {
+        match self.internal_run() {
+            Ok(()) => 0,
+            Err(err) => {
+                self.ui.log_error(&err.to_string());
+                1
+            }
+        }
+    }
+
+    fn internal_run(&mut self) -> Result<(), AppError> {
         self.add_default_branch_to_protected_branches()?;
         if self.fetch {
             self.fetch_changes()?;
@@ -401,10 +411,7 @@ pub fn run(args: CliArgs, dir: &str) -> i32 {
         return 1;
     }
 
-    match app.run() {
-        Ok(()) => 0,
-        Err(_) => 1,
-    }
+    app.run()
 }
 
 /// Restores the current git branch when dropped

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use crate::appui::{AppUi, BranchToDeleteInfo};
 use crate::batchappui::BatchAppUi;
 use crate::cliargs::CliArgs;
-use crate::git::{BranchRestorer, GitError, Repository};
+use crate::git::{GitError, Repository};
 use crate::interactiveappui::InteractiveAppUi;
 
 pub static DEFAULT_BRANCH_CONFIG_KEY: &str = "git-bonsai.default-branch";
@@ -404,5 +404,30 @@ pub fn run(args: CliArgs, dir: &str) -> i32 {
     match app.run() {
         Ok(()) => 0,
         Err(_) => 1,
+    }
+}
+
+/// Restores the current git branch when dropped
+/// Assumes we are on a real branch
+pub struct BranchRestorer<'a> {
+    repository: &'a Repository,
+    branch: String,
+}
+
+impl BranchRestorer<'_> {
+    pub fn new(repo: &Repository) -> BranchRestorer<'_> {
+        let current_branch = repo.get_current_branch().expect("Can't get current branch");
+        BranchRestorer {
+            repository: repo,
+            branch: current_branch,
+        }
+    }
+}
+
+impl Drop for BranchRestorer<'_> {
+    fn drop(&mut self) {
+        if let Err(_x) = self.repository.checkout(&self.branch) {
+            println!("Failed to restore original branch {}", self.branch);
+        }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -162,10 +162,10 @@ impl App {
                 self.ui.log_error("Failed to checkout branch");
                 return Err(AppError::Git(x));
             }
-            if let Err(_x) = self.repo.update_branch() {
-                self.ui.log_warning("Failed to update branch");
-                // This is not wrong, it can happen if the branches have diverged
-                // let's continue
+            if self.repo.fast_forward_branch().is_err() {
+                // Fast forward can fail if the branches have diverged. This is not a fatal error.
+                // Just continue with the next branch.
+                self.ui.log_warning("Can't fast-forward branch");
             }
         }
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -339,10 +339,7 @@ impl App {
             if branch_set.len() == 1 {
                 continue;
             }
-            if let Err(x) = self.do_delete_identical_branches(&sha1, &branch_set) {
-                self.ui.log_error("Failed to list branches");
-                return Err(x);
-            }
+            self.do_delete_identical_branches(&sha1, &branch_set)?;
         }
 
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ pub static DEFAULT_BRANCH_CONFIG_KEY: &str = "git-bonsai.default-branch";
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum AppError {
-    #[error("git error")]
+    #[error(transparent)]
     Git(#[from] GitError),
     #[error("this branch cannot be deleted safely")]
     UnsafeDelete,

--- a/src/app.rs
+++ b/src/app.rs
@@ -155,7 +155,7 @@ impl App {
             }
         };
 
-        let _restorer = BranchRestorer::new(&self.repo);
+        let _restorer = BranchRestorer::new(&self.repo, self.ui.as_ref());
         for branch in branches {
             self.ui.log_info(&format!("Updating {}", branch));
             if let Err(x) = self.repo.checkout(&branch) {
@@ -409,25 +409,30 @@ pub fn run(args: CliArgs, dir: &str) -> i32 {
 
 /// Restores the current git branch when dropped
 /// Assumes we are on a real branch
-pub struct BranchRestorer<'a> {
-    repository: &'a Repository,
+pub struct BranchRestorer<'r, 'u> {
+    repository: &'r Repository,
+    ui: &'u dyn AppUi,
     branch: String,
 }
 
-impl BranchRestorer<'_> {
-    pub fn new(repo: &Repository) -> BranchRestorer<'_> {
+impl<'r, 'u> BranchRestorer<'r, 'u> {
+    pub fn new(repo: &'r Repository, ui: &'u dyn AppUi) -> BranchRestorer<'r, 'u> {
         let current_branch = repo.get_current_branch().expect("Can't get current branch");
         BranchRestorer {
             repository: repo,
+            ui,
             branch: current_branch,
         }
     }
 }
 
-impl Drop for BranchRestorer<'_> {
+impl<'r, 'u> Drop for BranchRestorer<'r, 'u> {
     fn drop(&mut self) {
         if let Err(_x) = self.repository.checkout(&self.branch) {
-            println!("Failed to restore original branch {}", self.branch);
+            self.ui.log_warning(&format!(
+                "Failed to restore original branch {}",
+                self.branch
+            ));
         }
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+use std::borrow::Cow;
 use std::env;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -41,10 +42,14 @@ type GitResult<T> = Result<T, GitError>;
 pub enum GitError {
     #[error("failed to run git: {0}")]
     FailedToRunGit(String),
-    #[error("command exited with code {exit_code:?}: {stderr:?}")]
-    CommandFailed { exit_code: i32, stderr: String },
-    #[error("terminated by signal")]
-    TerminatedBySignal,
+    #[error("command `{command}` exited with code {exit_code}:\n{stderr}")]
+    CommandFailed {
+        command: String,
+        exit_code: i32,
+        stderr: String,
+    },
+    #[error("command `{command}` terminated by signal")]
+    TerminatedBySignal { command: String },
     #[error("unexpected output: {0}")]
     UnexpectedOutput(String),
 }
@@ -90,12 +95,16 @@ impl Repository {
             }
         };
         if !output.status.success() {
+            let command_str = get_command_str(&cmd);
             return match output.status.code() {
                 Some(code) => Err(GitError::CommandFailed {
+                    command: command_str,
                     exit_code: code,
                     stderr: String::from_utf8_lossy(&output.stderr).into(),
                 }),
-                None => Err(GitError::TerminatedBySignal),
+                None => Err(GitError::TerminatedBySignal {
+                    command: command_str,
+                }),
             };
         }
         let out = String::from_utf8(output.stdout).expect("Failed to decode command stdout");
@@ -269,6 +278,16 @@ pub fn create_test_repository(path: &Path) -> Repository {
     repo.git("commit", &["-m", "init"]).expect("commit failed");
 
     repo
+}
+
+/// Returns a string version of command executed by [cmd]
+fn get_command_str(cmd: &Command) -> String {
+    let mut parts: Vec<Cow<'_, str>> = vec![cmd.get_program().to_string_lossy()];
+    for arg in cmd.get_args() {
+        parts.push(arg.to_string_lossy());
+    }
+    // TODO implement quoting
+    parts.join(" ")
 }
 
 #[cfg(test)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -39,8 +39,8 @@ type GitResult<T> = Result<T, GitError>;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum GitError {
-    #[error("failed to run git")]
-    FailedToRunGit,
+    #[error("failed to run git: {0}")]
+    FailedToRunGit(String),
     #[error("command exited with code {exit_code:?}: {stderr:?}")]
     CommandFailed { exit_code: i32, stderr: String },
     #[error("terminated by signal")]
@@ -85,9 +85,8 @@ impl Repository {
         }
         let output = match cmd.output() {
             Ok(x) => x,
-            Err(_x) => {
-                println!("Failed to execute process");
-                return Err(GitError::FailedToRunGit);
+            Err(x) => {
+                return Err(GitError::FailedToRunGit(x.to_string()));
             }
         };
         if !output.status.success() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -49,33 +49,6 @@ pub enum GitError {
     UnexpectedOutput(String),
 }
 
-/**
- * Restores the current git branch when dropped
- * Assumes we are on a real branch
- */
-pub struct BranchRestorer<'a> {
-    repository: &'a Repository,
-    branch: String,
-}
-
-impl BranchRestorer<'_> {
-    pub fn new(repo: &Repository) -> BranchRestorer<'_> {
-        let current_branch = repo.get_current_branch().expect("Can't get current branch");
-        BranchRestorer {
-            repository: repo,
-            branch: current_branch,
-        }
-    }
-}
-
-impl Drop for BranchRestorer<'_> {
-    fn drop(&mut self) {
-        if let Err(_x) = self.repository.checkout(&self.branch) {
-            println!("Failed to restore original branch {}", self.branch);
-        }
-    }
-}
-
 pub struct Repository {
     pub path: PathBuf,
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -241,9 +241,9 @@ impl Repository {
         None
     }
 
-    pub fn update_branch(&self) -> GitResult<()> {
-        let out = self.git("merge", &["--ff-only"])?;
-        println!("{}", out);
+    /// Update the current branch to its upstream if it can be fast-forwarded
+    pub fn fast_forward_branch(&self) -> GitResult<()> {
+        self.git("merge", &["--ff-only"])?;
         Ok(())
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -182,7 +182,10 @@ impl Repository {
             if line.starts_with(WORKTREE_BRANCH_PREFIX) {
                 continue;
             }
-            let branch = line.get(2..).expect("Invalid branch name");
+            let Some(branch) = line.get(2..) else {
+                let msg = format!("invalid line in `git branch` output: {line}");
+                return Err(GitError::UnexpectedOutput(msg));
+            };
             branches.push(branch.to_string());
         }
         Ok(branches)


### PR DESCRIPTION
- **Move BranchRestorer to app.rs**
- **Use appui to show BranchRestorer warning**
- **app: if a step fails with an error, always log it with log_error**
- **git: remove the print when git fails to start, return the error details**
- **git: replace one panic! with an error**
- **app: take advantage of the fact that we log errors at the end**
- **Fix git error messages not showing up**
- **git: include the git command in error messages**
- **git.update_branch: remove println, rename function**
